### PR TITLE
[Riak] Report latencies as milliseconds

### DIFF
--- a/riak/plugins/riak.py
+++ b/riak/plugins/riak.py
@@ -14,7 +14,7 @@ except Exception, e:
 result = "OK | "
 for k, v in resp.iteritems():
     if isinstance(v, int) or isinstance(v, float):
-            if 'time' in k:
+            if 'time' in k or 'latency' in k:
                 result += str(k) + '=' + str(v/1000) + 'ms;;;; '
             else:
                 result += str(k) + '=' + str(v) + ';;;; '


### PR DESCRIPTION
Riak reports search related timings with tags containing "latency" instead of "time".
Apply the same conversion to milliseconds as for other time values.
