### PR TITLE
[base] check /dev/mapper via an os list

### DIFF
--- a/base/plugins/base.py
+++ b/base/plugins/base.py
@@ -165,7 +165,7 @@ def check_diskio():
 
         # check for any device mapper partitions
         for partition in psutil.disk_partitions():
-            if '/dev/mapper' in partition.device:
+            if 'mapper' in os.listdir('/dev'):
                 dm = True
         # per device mapper friendly name io counters
         if dm:


### PR DESCRIPTION
inside a docker container, psutils is returning all the host mounts,
not the ones only accessible inside the container